### PR TITLE
Changed the way the C++ standard is set in the cmakelists so that it actually works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ project(${PROJECT_NAME})
 
 aux_source_directory("src" henifig_src)
 add_library(${PROJECT_NAME} ${henifig_src})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
-set(CMAKE_CXX_STANDARD 17)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
 target_include_directories(${PROJECT_NAME} PUBLIC "include")


### PR DESCRIPTION
Why does VC++ still use C++14 by default anyway